### PR TITLE
:memo: broken link to CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The plan is to use the community server and host each individuals dashboard on a
 The following documents provided further information
 
 Contributions are much appreciated, be they bug reports, ideas or patches. See the file for more information.
- * [Contributing](docs/CONTRIBUTING.md)
+ * [Contributing](CONTRIBUTING.md)
 
 ---
 


### PR DESCRIPTION
It's at the repo's root because required by Github to be so.