### PR TITLE
:sparkles: Advanced version of ScratchPad with save

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -34,6 +34,7 @@
                 "ts": "never",
                 "tsx": "never"
             }
-        ]
+        ],
+        "import/prefer-default-export": "off"
     }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",
+    "@types/jest": "^27.0.3",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
     "react": "^17.0.2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import './App.css';
-import ScratchPad from './components/ScratchPad';
+import ScratchPad from './components/ScratchPad/ScrathPad';
 
 const App = () => <ScratchPad />;
 

--- a/frontend/src/components/ScratchPad/ScrathPad.tsx
+++ b/frontend/src/components/ScratchPad/ScrathPad.tsx
@@ -10,7 +10,7 @@ const ScratchPad = () => {
     <Card>
       <h2 className="scratch-title">Scratchpad</h2>
       <p className="scratch-loading">{loadingText}</p>
-      <textarea className="scratch-area" value={value} onChange={onChangeHandler} />
+      <textarea className="scratch-area" value={value} data-testid="scratch-pad" onChange={onChangeHandler} />
     </Card>
   );
 };

--- a/frontend/src/components/ScratchPad/ScrathPad.tsx
+++ b/frontend/src/components/ScratchPad/ScrathPad.tsx
@@ -1,18 +1,15 @@
-import React, { useCallback, useState } from 'react';
+import React from 'react';
 import Card from '../Card';
 import './stylesheet.css';
-import data from '../../mocks/scratchpad-data.json';
+import { useScratchPad } from './hooks';
 
 const ScratchPad = () => {
-  const [value, setValue] = useState<string>(data.text);
-
-  const onChangeHandler = useCallback((e) => {
-    setValue(e.target.value);
-  });
+  const { loadingText, value, onChangeHandler } = useScratchPad();
 
   return (
     <Card>
       <h2 className="scratch-title">Scratchpad</h2>
+      <p className="scratch-loading">{loadingText}</p>
       <textarea className="scratch-area" value={value} onChange={onChangeHandler} />
     </Card>
   );

--- a/frontend/src/components/ScratchPad/__tests__/ScratchPad.spec.tsx
+++ b/frontend/src/components/ScratchPad/__tests__/ScratchPad.spec.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import ScratchPad from '../ScrathPad';
+import { SAVED } from '../constants';
+import data from '../../../mocks/scratchpad-data.json';
+import { getFromStorage } from '../../../modules/storage/io';
+
+const SAMPLE_TEXT = 'Hello world 🚀';
+
+jest.mock('../../../modules/storage/io');
+
+describe('ScratchPad', () => {
+  it('should render with saved string', () => {
+    const { getByText } = render(<ScratchPad />);
+    expect(getByText(SAVED)).toBeDefined();
+  });
+
+  it('should render with stored text', () => {
+    (getFromStorage as jest.Mock).mockReturnValueOnce(SAMPLE_TEXT);
+    const { getByDisplayValue } = render(<ScratchPad />);
+    expect(getByDisplayValue(SAMPLE_TEXT)).toBeDefined();
+  });
+
+  it('should render with default text', () => {
+    const { getByDisplayValue } = render(<ScratchPad />);
+    expect(getByDisplayValue(data.text)).toBeDefined();
+  });
+});

--- a/frontend/src/components/ScratchPad/__tests__/ScratchPad.spec.tsx
+++ b/frontend/src/components/ScratchPad/__tests__/ScratchPad.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import ScratchPad from '../ScrathPad';
-import { SAVED } from '../constants';
+import { SAVED, SAVING } from '../constants';
 import data from '../../../mocks/scratchpad-data.json';
 import { getFromStorage } from '../../../modules/storage/io';
 
@@ -13,6 +13,16 @@ describe('ScratchPad', () => {
   it('should render with saved string', () => {
     const { getByText } = render(<ScratchPad />);
     expect(getByText(SAVED)).toBeDefined();
+  });
+
+  it('should change state while typing', async () => {
+    const { getByTestId, getByText } = render(<ScratchPad />);
+    const textArea = getByTestId('scratch-pad');
+    fireEvent.change(textArea, { target: { value: '' } });
+    await expect(getByText(SAVING)).toBeDefined();
+    await waitFor(() => {
+      expect(getByText(SAVED)).toBeDefined();
+    });
   });
 
   it('should render with stored text', () => {

--- a/frontend/src/components/ScratchPad/__tests__/utils.spec.ts
+++ b/frontend/src/components/ScratchPad/__tests__/utils.spec.ts
@@ -1,0 +1,12 @@
+import { getStateText } from '../utils';
+import { SAVED, SAVING } from '../constants';
+
+describe('getStateText', () => {
+  it('should return save in progress string', () => {
+    expect(getStateText(true)).toEqual(SAVING);
+  });
+
+  it('should return save complete string', () => {
+    expect(getStateText(false)).toEqual(SAVED);
+  });
+});

--- a/frontend/src/components/ScratchPad/constants.ts
+++ b/frontend/src/components/ScratchPad/constants.ts
@@ -1,4 +1,6 @@
 export const SAVING = 'Saving changes...';
 export const SAVED = 'Saved ✅';
 
+export const SAVING_DELAY = 500;
+
 export const SCRATCHPAD_STORAGE_KEY = 'scratchpad_data';

--- a/frontend/src/components/ScratchPad/constants.ts
+++ b/frontend/src/components/ScratchPad/constants.ts
@@ -1,0 +1,4 @@
+export const SAVING = 'Saving changes...';
+export const SAVED = 'Saved ✅';
+
+export const SCRATCHPAD_STORAGE_KEY = 'scratchpad_data';

--- a/frontend/src/components/ScratchPad/hooks.ts
+++ b/frontend/src/components/ScratchPad/hooks.ts
@@ -1,0 +1,51 @@
+import {
+  ChangeEventHandler,
+  useCallback, useEffect, useMemo, useRef, useState,
+} from 'react';
+import { getFromStorage, saveToStorage } from '../../modules/storage/io';
+import { SCRATCHPAD_STORAGE_KEY } from './constants';
+import data from '../../mocks/scratchpad-data.json';
+import { getStateText } from './utils';
+
+type ScratchPadHook = {
+  loadingText: string
+  onChangeHandler: ChangeEventHandler
+  value: string
+};
+
+export const useScratchPad = (): ScratchPadHook => {
+  const [loading, setLoading] = useState<boolean>(false);
+  const [value, setValue] = useState<string>('');
+  const timer = useRef(null);
+
+  const onChangeHandler = useCallback((e) => {
+    setValue(e.target.value);
+    setLoading(true);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => {
+      saveToStorage(SCRATCHPAD_STORAGE_KEY, e.target.value);
+      setLoading(false);
+    }, 500);
+
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, []);
+
+  useEffect(() => {
+    const restoredData = getFromStorage(SCRATCHPAD_STORAGE_KEY);
+    if (restoredData) {
+      setValue(restoredData);
+    } else {
+      setValue(data.text);
+    }
+  }, []);
+
+  const loadingText = useMemo(() => getStateText(loading), [loading]);
+
+  return {
+    loadingText,
+    onChangeHandler,
+    value,
+  };
+};

--- a/frontend/src/components/ScratchPad/hooks.ts
+++ b/frontend/src/components/ScratchPad/hooks.ts
@@ -3,7 +3,7 @@ import {
   useCallback, useEffect, useMemo, useRef, useState,
 } from 'react';
 import { getFromStorage, saveToStorage } from '../../modules/storage/io';
-import { SCRATCHPAD_STORAGE_KEY } from './constants';
+import { SAVING_DELAY, SCRATCHPAD_STORAGE_KEY } from './constants';
 import data from '../../mocks/scratchpad-data.json';
 import { getStateText } from './utils';
 
@@ -25,7 +25,7 @@ export const useScratchPad = (): ScratchPadHook => {
     timer.current = setTimeout(() => {
       saveToStorage(SCRATCHPAD_STORAGE_KEY, e.target.value);
       setLoading(false);
-    }, 500);
+    }, SAVING_DELAY);
 
     return () => {
       if (timer.current) clearTimeout(timer.current);

--- a/frontend/src/components/ScratchPad/stylesheet.css
+++ b/frontend/src/components/ScratchPad/stylesheet.css
@@ -15,5 +15,10 @@
     border-radius: 5px;
 }
 
+.scratch-loading {
+    margin: 0;
+    font-size: 12px;
+}
+
 .scratch-area:focus {
 }

--- a/frontend/src/components/ScratchPad/utils.ts
+++ b/frontend/src/components/ScratchPad/utils.ts
@@ -1,0 +1,3 @@
+import { SAVED, SAVING } from './constants';
+
+export const getStateText = (loading: boolean): string => (loading ? SAVING : SAVED);

--- a/frontend/src/mocks/scratchpad-data.json
+++ b/frontend/src/mocks/scratchpad-data.json
@@ -1,3 +1,3 @@
 {
-  "text": "I can write something freely!\nThis is so cooool ✨\n\nToday i need to rest a little bit\n\nAnd of course, code!"
+  "text": "Write anything! ✨"
 }

--- a/frontend/src/modules/storage/io.ts
+++ b/frontend/src/modules/storage/io.ts
@@ -1,0 +1,5 @@
+export const saveToStorage = (key: string, data: string) => {
+  localStorage.setItem(key, data);
+};
+
+export const getFromStorage = (key: string): string => localStorage.getItem(key);

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1514,7 +1514,7 @@
 
 "@testing-library/react@^12.1.2":
   version "12.1.2"
-  resolved "https://registry.npmjs.org/@testing-library/react/-/react-12.1.2.tgz"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.2.tgz#f1bc9a45943461fa2a598bb4597df1ae044cfc76"
   integrity sha512-ihQiEOklNyHIpo2Y8FREkyD1QAea054U0MVbwH1m8N9TxeFz+KoJ9LkqoKqJlzx2JDm56DVwaJ1r36JYxZM05g==
   dependencies:
     "@babel/runtime" "^7.12.5"
@@ -1657,6 +1657,14 @@
 "@types/jest@*":
   version "27.0.3"
   resolved "https://registry.npmjs.org/@types/jest/-/jest-27.0.3.tgz"
+  integrity sha512-cmmwv9t7gBYt7hNKH5Spu7Kuu/DotGa+Ff+JGRKZ4db5eh8PnKS4LuebJ3YLUoyOyIHraTGyULn23YtEAm0VSg==
+  dependencies:
+    jest-diff "^27.0.0"
+    pretty-format "^27.0.0"
+
+"@types/jest@^27.0.3":
+  version "27.0.3"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.0.3.tgz#0cf9dfe9009e467f70a342f0f94ead19842a783a"
   integrity sha512-cmmwv9t7gBYt7hNKH5Spu7Kuu/DotGa+Ff+JGRKZ4db5eh8PnKS4LuebJ3YLUoyOyIHraTGyULn23YtEAm0VSg==
   dependencies:
     jest-diff "^27.0.0"


### PR DESCRIPTION
## Here is an advanced version of the ScratchPad!
It's basically the same, but while you are typing, it says `saving changes`, then when you stop, it actually saves it to your computer. It's using `localStorage`. Further improvements could be saving to a remote backend for example.

| While typing | After typing |
| --- | --- |
| ![Screenshot from 2021-12-17 21-40-16](https://user-images.githubusercontent.com/23266335/146605392-fe1bd6de-c796-4ece-88fb-e54d9ada98d2.png) | ![Screenshot from 2021-12-17 21-40-30](https://user-images.githubusercontent.com/23266335/146605404-b841427b-937d-4ad0-94b8-50d81403e087.png) |

#### Some unit tests are provided
