### PR TITLE
:sparkles: Add a router for the application

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "luxon": "^2.2.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-router-dom": "^6.2.1",
     "react-scripts": "5.0.0",
     "web-vitals": "^2.1.2"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,9 +18,9 @@ const App = () => (
               <ScratchPad />
             </div>
           </div>
-)}
+        )}
       />
-      <Route path="/" element={<NavLink to="/longlikeshort">Go to longlikeshort dashboard</NavLink>} />
+      <Route index element={<NavLink to="/longlikeshort">Go to longlikeshort dashboard</NavLink>} />
     </Routes>
   </BrowserRouter>
 );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,15 +1,28 @@
 import React from 'react';
 import './App.css';
+import {
+  BrowserRouter, NavLink, Route, Routes,
+} from 'react-router-dom';
 import ScratchPad from './components/ScratchPad/ScrathPad';
 import Table from './components/Table/Table';
 
 const App = () => (
-  <div className="layout">
-    <Table />
-    <div>
-      <ScratchPad />
-    </div>
-  </div>
+  <BrowserRouter>
+    <Routes>
+      <Route
+        path="/:username"
+        element={(
+          <div className="layout">
+            <Table />
+            <div>
+              <ScratchPad />
+            </div>
+          </div>
+)}
+      />
+      <Route path="/" element={<NavLink to="/longlikeshort">Go to longlikeshort dashboard</NavLink>} />
+    </Routes>
+  </BrowserRouter>
 );
 
 export default App;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1014,7 +1014,7 @@
     core-js-pure "^3.19.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.16.5"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz"
   integrity sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==
@@ -4361,6 +4361,13 @@ he@^1.2.0:
   resolved "https://registry.npmjs.org/he/-/he-1.2.0.tgz"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+history@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.2.0.tgz#7cdd31cf9bac3c5d31f09c231c9928fad0007b7c"
+  integrity sha512-uPSF6lAJb3nSePJ43hN3eKj1dTWpN9gMod0ZssbFTIsen+WehTmEadgL+kg78xLJFdRfrrC//SavDzmRVdE+Ig==
+  dependencies:
+    "@babel/runtime" "^7.7.6"
+
 hoopy@^0.1.4:
   version "0.1.4"
   resolved "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz"
@@ -6998,6 +7005,21 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
+
+react-router-dom@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.2.1.tgz#32ec81829152fbb8a7b045bf593a22eadf019bec"
+  integrity sha512-I6Zax+/TH/cZMDpj3/4Fl2eaNdcvoxxHoH1tYOREsQ22OKDYofGebrNm6CTPUcvLvZm63NL/vzCYdjf9CUhqmA==
+  dependencies:
+    history "^5.2.0"
+    react-router "6.2.1"
+
+react-router@6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.2.1.tgz#be2a97a6006ce1d9123c28934e604faef51448a3"
+  integrity sha512-2fG0udBtxou9lXtK97eJeET2ki5//UWfQSl1rlJ7quwe6jrktK9FCCc8dQb5QY6jAv3jua8bBQRhhDOM/kVRsg==
+  dependencies:
+    history "^5.2.0"
 
 react-scripts@5.0.0:
   version "5.0.0"


### PR DESCRIPTION
# Adding a router package and a basic routing

## New dependency

It is using `react-router@6`, here is [the official documentation](https://reactrouter.com/docs/en/v6)

## In the code

I just added the router to the `App` root component, and embedded the components in the route `/longlikeshort`.
Homepage have a link to this route not to get lost.