### PR TITLE
:passport_control: Cross origin auth

### DIFF
--- a/backend/src/routers/auth.ts
+++ b/backend/src/routers/auth.ts
@@ -10,8 +10,9 @@ const authRouter = new Router();
 authRouter.post('/discord', async (ctx, next) => {
   try {
     const { code } = ctx.request.body;
+    const origin = ctx.get('Origin');
     const { email, username, discordCredentialsEntity, id, avatar } =
-      await generateAndStoreDiscordCredentials(code);
+      await generateAndStoreDiscordCredentials(code, origin);
     let user = await User.findOne({ email });
     if (!user) {
       user = new User({

--- a/backend/src/services/discordService.ts
+++ b/backend/src/services/discordService.ts
@@ -25,21 +25,24 @@ type DiscordUser = {
 };
 
 export const exchangeTokenWithAuthToken = async (
-  code: string
+  code: string,
+  origin: string
 ): Promise<TokenResponse> => {
   const payload = {
     client_id: process.env.CLIENT_ID,
     client_secret: process.env.CLIENT_SECRET,
     grant_type: 'authorization_code',
     code,
-    redirect_uri: process.env.REDIRECT_URI,
+    redirect_uri: `${origin}/`,
   };
+  console.log(payload);
   const response = await fetch(process.env.DISCORD_API + '/oauth2/token', {
     method: 'POST',
     headers: generateContentTypeHeader('application/x-www-form-urlencoded'),
     body: generateSearchParams(payload),
   });
   const data = await response.json();
+  console.log(data);
   if (data.error) throw new Error(data.error_description);
   return data;
 };
@@ -49,9 +52,10 @@ type GenerateAndStoreDiscordCredentials = DiscordUser & {
 };
 
 export const generateAndStoreDiscordCredentials = async (
-  code: string
+  code: string,
+  origin: string
 ): Promise<GenerateAndStoreDiscordCredentials> => {
-  const discordData = await exchangeTokenWithAuthToken(code);
+  const discordData = await exchangeTokenWithAuthToken(code, origin);
   const discordUser = await getCurrentUser(discordData.access_token);
   const discordCredentialsEntity = new DiscordCredentials({
     accessToken: discordData.access_token,


### PR DESCRIPTION
# Cross origin redirect URI

Because we want to use the preview API `ziro.cchampou.me/api` for front-end only developments, this PR allows authentication calls from any origin, using it as callback URI.

:information_source: **There is still control over the URL because only a few are authorized in Discord application settings.**