### PR TITLE
:construction_worker: Backend code style checks in CI

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,0 +1,34 @@
+name: Backend CI
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  "code-styling":
+    name: "ESLint & Prettier checks"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+
+    strategy:
+      matrix:
+        node-version: [ 16.x ]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+          cache-dependency-path: ./backend/yarn.lock
+      - run: yarn install
+        name: Install dependencies
+      - run: yarn lint
+        name: Run lint
+      - run: yarn prettier
+        name: Run prettier

--- a/backend/package.json
+++ b/backend/package.json
@@ -37,7 +37,8 @@
     "prebuild": "yarn lint",
     "build": "tsc",
     "build:dev": "tsc -w",
-    "lint": "tslint -p tsconfig.json -c tslint.json --fix",
+    "lint": "tslint -p tsconfig.json -c tslint.json",
+    "prettier": "prettier src -c",
     "serve": "node dist",
     "serve:dev": "nodemon dist"
   }


### PR DESCRIPTION
# GitHub Actions update

Adding a back-end CI with a step for code style checks, running `yarn run lint` & `yarn run prettier` which are respectively using `tslint` & `prettier`.