### PR TITLE
:lock: Increase token lifespan to `12 hours`

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -5,3 +5,4 @@ REDIRECT_URI=https://ziro.cchampou.me/
 DATABASE_URL=mongodb://username:password@host/database
 AUTH_SECRET=xxxxx
 WHITELISTED_DISCORD_IDS=231067879179550720
+TOKEN_LIFESPAN=43200

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -7,7 +7,7 @@ export const generateJWT = async (userId: string): Promise<string> => {
     },
     process.env.AUTH_SECRET,
     {
-      expiresIn: 3600,
+      expiresIn: process.env.TOKEN_LIFESPAN,
     }
   );
 };


### PR DESCRIPTION
Given the security criticality which is not so high, it updates the token lifespan to 12 hours. With this, there is a few chances of needing to re-log within one work session. It also we don't need refresh tokens for now.