### PR TITLE
:sparkles: Remote save of Scratchpad

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "yarn lint:code; yarn lint:docs",
-    "lint:code": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "lint:code": "eslint . --ext .js,.jsx,.ts,.tsx --max-warnings=0",
     "lint:docs": "markdownlint . -i node_modules",
     "prettier": "prettier src -c",
     "security": "yarn-audit-ci"

--- a/frontend/src/components/ScratchPad/ScrathPad.tsx
+++ b/frontend/src/components/ScratchPad/ScrathPad.tsx
@@ -4,11 +4,11 @@ import './stylesheet.css';
 import { useScratchPad } from './hooks';
 
 type ScratchPadProps = {
-  defaultText: string;
+  text: string;
 };
 
-const ScratchPad: FC<ScratchPadProps> = ({ defaultText }) => {
-  const { loadingText, value, onChangeHandler } = useScratchPad(defaultText);
+const ScratchPad: FC<ScratchPadProps> = ({ text }) => {
+  const { loadingText, value, onChangeHandler } = useScratchPad(text);
 
   return (
     <Card className="flex-column scratch-card">

--- a/frontend/src/components/ScratchPad/__tests__/ScratchPad.spec.tsx
+++ b/frontend/src/components/ScratchPad/__tests__/ScratchPad.spec.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import ScratchPad from '../ScrathPad';
 import { SAVED, SAVING } from '../constants';
-import { getFromStorage } from '../../../modules/storage/io';
 
 const SAMPLE_TEXT = 'Hello world 🚀';
 

--- a/frontend/src/components/ScratchPad/__tests__/ScratchPad.spec.tsx
+++ b/frontend/src/components/ScratchPad/__tests__/ScratchPad.spec.tsx
@@ -10,13 +10,13 @@ jest.mock('../../../modules/storage/io');
 
 describe('ScratchPad', () => {
   it('should render with saved string', () => {
-    const { getByText } = render(<ScratchPad defaultText={SAMPLE_TEXT} />);
+    const { getByText } = render(<ScratchPad text={SAMPLE_TEXT} />);
     expect(getByText(SAVED)).toBeDefined();
   });
 
   it('should change state while typing', async () => {
     const { getByTestId, getByText } = render(
-      <ScratchPad defaultText={SAMPLE_TEXT} />
+      <ScratchPad text={SAMPLE_TEXT} />
     );
     const textArea = getByTestId('scratch-pad');
     fireEvent.change(textArea, { target: { value: '' } });
@@ -26,18 +26,8 @@ describe('ScratchPad', () => {
     });
   });
 
-  it('should render with stored text', () => {
-    (getFromStorage as jest.Mock).mockReturnValueOnce(SAMPLE_TEXT);
-    const { getByDisplayValue } = render(
-      <ScratchPad defaultText="Wrong data" />
-    );
-    expect(getByDisplayValue(SAMPLE_TEXT)).toBeDefined();
-  });
-
-  it('should render with default text', () => {
-    const { getByDisplayValue } = render(
-      <ScratchPad defaultText={SAMPLE_TEXT} />
-    );
+  it('should render with given text', () => {
+    const { getByDisplayValue } = render(<ScratchPad text={SAMPLE_TEXT} />);
     expect(getByDisplayValue(SAMPLE_TEXT)).toBeDefined();
   });
 });

--- a/frontend/src/components/ScratchPad/hooks.ts
+++ b/frontend/src/components/ScratchPad/hooks.ts
@@ -6,9 +6,10 @@ import {
   useRef,
   useState,
 } from 'react';
-import { getFromStorage, saveToStorage } from '../../modules/storage/io';
-import { SAVING_DELAY, SCRATCHPAD_STORAGE_KEY } from './constants';
+import _ from 'lodash';
+import { SAVING_DELAY } from './constants';
 import { getStateText } from './utils';
+import { request } from '../../modules/http/client';
 
 type ScratchPadHook = {
   loadingText: string;
@@ -16,7 +17,7 @@ type ScratchPadHook = {
   value: string;
 };
 
-export const useScratchPad = (defaultText: string): ScratchPadHook => {
+export const useScratchPad = (text: string): ScratchPadHook => {
   const [loading, setLoading] = useState<boolean>(false);
   const [value, setValue] = useState<string>('');
   const timer = useRef(null);
@@ -26,7 +27,7 @@ export const useScratchPad = (defaultText: string): ScratchPadHook => {
     setLoading(true);
     if (timer.current) clearTimeout(timer.current);
     timer.current = setTimeout(() => {
-      saveToStorage(SCRATCHPAD_STORAGE_KEY, e.target.value);
+      request('/user', 'PATCH', { scratchpad: e.target.value }).catch(_.noop);
       setLoading(false);
     }, SAVING_DELAY);
 
@@ -36,13 +37,8 @@ export const useScratchPad = (defaultText: string): ScratchPadHook => {
   }, []);
 
   useEffect(() => {
-    const restoredData = getFromStorage(SCRATCHPAD_STORAGE_KEY);
-    if (restoredData) {
-      setValue(restoredData);
-    } else {
-      setValue(defaultText);
-    }
-  }, []);
+    setValue(text);
+  }, [text]);
 
   const loadingText = useMemo(() => getStateText(loading), [loading]);
 

--- a/frontend/src/entities/User.ts
+++ b/frontend/src/entities/User.ts
@@ -11,5 +11,5 @@ export type User = {
   discordAvatar: string;
 };
 
-export const fetchUser = (username: string) => () =>
-  request(`/user/${username}`);
+export const fetchUser = (username?: string) => () =>
+  request(username ? `/user/${username}` : '/user');

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -46,7 +46,7 @@ const Dashboard: FC<DashboardProps> = ({ readonly }) => {
         <Table data={data || []} readonly={readonly} />
         <div className="flex1">
           <Chart entries={data || []} />
-          {!readonly && <ScratchPad defaultText="Hello world" />}
+          {!readonly && <ScratchPad text={user?.scratchpad} />}
         </div>
       </div>
     </>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -30,7 +30,9 @@ const Dashboard: FC<DashboardProps> = ({ readonly }) => {
 
   const { data: user } = useQuery(
     ['user', username],
-    fetchUser(usernameToQuery),
+    fetchUser(
+      loggedInUser.username !== usernameToQuery ? usernameToQuery : undefined
+    ),
     { enabled: Boolean(usernameToQuery) }
   );
 


### PR DESCRIPTION
It saves the data via a PATCH request to the user entity instead of writing to local storage.

Data is taken from the user request.